### PR TITLE
Dissertation Director name should at the second line

### DIFF
--- a/rutgersthesis.cls
+++ b/rutgersthesis.cls
@@ -381,7 +381,8 @@ Date approved: \@approvaldate
 \vspace{\baselineskip}
 by \MakeUppercase{\yourName}\\
 \vspace{\baselineskip}
-{\thesisType} Director: {\yourDirector}\\
+{\thesisType} Director:\\
+{\yourDirector}\\
 \vspace{2\baselineskip}
     \end{centering}
 }{


### PR DESCRIPTION
Just received an email from sgs.degree.submissions@grad.rutgers.edu saying that

```
On your abstract page please press enter after "Dissertation Director", (the name should be on a separate line).
```